### PR TITLE
Clean up and make geometry system threadsafe

### DIFF
--- a/larcore/CoreUtils/EnsureOnlyOneSchedule.h
+++ b/larcore/CoreUtils/EnsureOnlyOneSchedule.h
@@ -1,0 +1,43 @@
+#ifndef larcore_CoreUtils_EnsureOnlyOneSchedule_h
+#define larcore_CoreUtils_EnsureOnlyOneSchedule_h
+
+#include "art/Utilities/Globals.h"
+#include "canvas/Utilities/Exception.h"
+#include "cetlib_except/demangle.h"
+
+/**
+ * @file   EnsureOnlyOneSchedule.h
+ * @brief  Type whose constructor throws if more than one art schedule is configured
+ *
+ * This class is intended to be used in the context of an art job.  It
+ * is helpful for services that have the notion of a "current event,"
+ * but are thread-safe within that event.  The constructor of this
+ * class will throw an exception if more than one art schedule is
+ * configured.  It should be used via private inheritance:
+ *
+ *   class MyService : lar::EnsureOnlyOneSchedule<MyService> {
+ *     ..
+ *   };
+ *
+ */
+
+namespace lar {
+  template <typename T>
+  class EnsureOnlyOneSchedule {
+  public:
+    EnsureOnlyOneSchedule()
+    {
+      if (auto const nschedules = art::Globals::instance()->nschedules(); nschedules > 1) {
+        throw art::Exception{art::errors::Configuration}
+        << "This job uses " << nschedules << " schedules, but the type '" << cet::demangle_symbol(typeid(T).name()) << " supports\n"
+        << "processing only one event at a time. Please reconfigure your job to use only one schedule.\n";
+      }
+    }
+  };
+}
+
+#endif /* larcore_CoreUtils_EnsureOnlyOneSchedule_h */
+
+// Local Variables:
+// mode: c++
+// End:

--- a/larcore/Geometry/AuxDetExptGeoHelperInterface.h
+++ b/larcore/Geometry/AuxDetExptGeoHelperInterface.h
@@ -28,7 +28,7 @@
 #include "fhiclcpp/ParameterSet.h"
 
 // C/C++ standard libraries
-#include <memory> // std::shared_ptr<>
+#include <memory> // std::unique_ptr<>
 #include <vector>
 
 
@@ -36,7 +36,6 @@
 namespace geo
 {
   class AuxDetChannelMapAlg;
-  class AuxDetGeometryCore;
 }
 
 namespace geo
@@ -61,7 +60,7 @@ namespace geo
   class AuxDetExptGeoHelperInterface
   {
   public:
-    using AuxDetChannelMapAlgPtr_t = std::shared_ptr<const AuxDetChannelMapAlg>;
+    using AuxDetChannelMapAlgPtr_t = std::unique_ptr<AuxDetChannelMapAlg>;
 
     /// Virtual destructor; does nothing
     virtual ~AuxDetExptGeoHelperInterface() = default;
@@ -76,24 +75,14 @@ namespace geo
      * specified configuration, then it configures the geometry itself
      * according to the channel map (usually, it resorts the data).
      */
-    void ConfigureAuxDetChannelMapAlg(fhicl::ParameterSet const & sortingParameters,
-                                      geo::AuxDetGeometryCore* geom);
-
-    /// Returns null pointer if the initialization failed
-    /// NOTE:  the sub-class owns the ChannelMapAlg object
-    ///
-    AuxDetChannelMapAlgPtr_t GetAuxDetChannelMapAlg() const;
+    AuxDetChannelMapAlgPtr_t
+    ConfigureAuxDetChannelMapAlg(fhicl::ParameterSet const & sortingParameters) const;
 
   private:
 
     /// Implementation of ConfigureChannelMapAlg (pure virtual)
-    virtual
-    void doConfigureAuxDetChannelMapAlg(fhicl::ParameterSet const & sortingParameters,
-                                        geo::AuxDetGeometryCore* geom) = 0;
-
-    /// Returns the ChannelMapAlg
-    virtual
-    AuxDetChannelMapAlgPtr_t doGetAuxDetChannelMapAlg() const    = 0;
+    virtual AuxDetChannelMapAlgPtr_t
+    doConfigureAuxDetChannelMapAlg(fhicl::ParameterSet const & sortingParameters) const = 0;
 
   }; // end ExptGeoHelperInterface class declaration
 
@@ -102,21 +91,14 @@ namespace geo
   //-------------------------------------------------------------------------------------------
 
   inline
-  void AuxDetExptGeoHelperInterface::ConfigureAuxDetChannelMapAlg
-    (fhicl::ParameterSet const& sortingParameters, geo::AuxDetGeometryCore* geom)
+  AuxDetExptGeoHelperInterface::AuxDetChannelMapAlgPtr_t
+  AuxDetExptGeoHelperInterface::ConfigureAuxDetChannelMapAlg(fhicl::ParameterSet const& sortingParameters) const
   {
-    doConfigureAuxDetChannelMapAlg(sortingParameters, geom);
+    return doConfigureAuxDetChannelMapAlg(sortingParameters);
   }
 
-  inline
-  AuxDetExptGeoHelperInterface::AuxDetChannelMapAlgPtr_t
-    AuxDetExptGeoHelperInterface::GetAuxDetChannelMapAlg() const
-  {
-    return doGetAuxDetChannelMapAlg();
-  }
 }
 
-DECLARE_ART_SERVICE_INTERFACE(geo::AuxDetExptGeoHelperInterface, LEGACY)
+DECLARE_ART_SERVICE_INTERFACE(geo::AuxDetExptGeoHelperInterface, SHARED)
 
 #endif // GEO_ExptGeoHelperInterface_h
-

--- a/larcore/Geometry/AuxDetGeometry.h
+++ b/larcore/Geometry/AuxDetGeometry.h
@@ -95,9 +95,6 @@ namespace geo {
 
     AuxDetGeometry(fhicl::ParameterSet const& pset, art::ActivityRegistry& reg);
 
-    /// Updates the geometry if needed at the beginning of each new run
-    void preBeginRun(art::Run const& run);
-
     /// Returns a constant reference to the service provider
     AuxDetGeometryCore const& GetProvider() const { return fProvider; }
 
@@ -105,6 +102,9 @@ namespace geo {
     AuxDetGeometryCore const* GetProviderPtr() const { return &GetProvider(); }
 
   private:
+
+    /// Updates the geometry if needed at the beginning of each new run
+    void preBeginRun(art::Run const& run);
 
     /// Expands the provided paths and loads the geometry description(s)
     void LoadNewGeometry(std::string gdmlfile, std::string rootfile);
@@ -129,6 +129,6 @@ namespace geo {
 
 } // namespace geo
 
-DECLARE_ART_SERVICE(geo::AuxDetGeometry, LEGACY)
+DECLARE_ART_SERVICE(geo::AuxDetGeometry, SHARED)
 
 #endif // GEO_AUXDETGEOMETRY_H

--- a/larcore/Geometry/AuxDetGeometry_service.cc
+++ b/larcore/Geometry/AuxDetGeometry_service.cc
@@ -30,7 +30,7 @@ namespace geo {
     : fProvider         (pset)
     , fRelPath          (pset.get< std::string       >("RelativePath",      ""   ))
     , fForceUseFCLOnly  (pset.get< bool              >("ForceUseFCLOnly" ,  false))
-    , fSortingParameters(pset.get<fhicl::ParameterSet>("SortingParameters", fhicl::ParameterSet() ))
+    , fSortingParameters(pset.get<fhicl::ParameterSet>("SortingParameters", {}))
   {
     // add a final directory separator ("/") to fRelPath if not already there
     if (!fRelPath.empty() && (fRelPath.back() != '/')) fRelPath += '/';
@@ -93,12 +93,11 @@ namespace geo {
   {
     // the channel map is responsible of calling the channel map configuration
     // of the geometry
-    art::ServiceHandle<geo::AuxDetExptGeoHelperInterface>()->ConfigureAuxDetChannelMapAlg(fSortingParameters, GetProviderPtr());
-
-    if ( ! GetProvider().hasAuxDetChannelMap() ) {
+    auto channelMap = art::ServiceHandle<geo::AuxDetExptGeoHelperInterface>()->ConfigureAuxDetChannelMapAlg(fSortingParameters);
+    if (!channelMap) {
       throw cet::exception("ChannelMapLoadFail") << " failed to load new channel map";
     }
-
+    fProvider.ApplyChannelMap(move(channelMap));
   } // Geometry::InitializeChannelMap()
 
   //......................................................................

--- a/larcore/Geometry/CMakeLists.txt
+++ b/larcore/Geometry/CMakeLists.txt
@@ -2,13 +2,13 @@ art_make(SERVICE_LIBRARIES larcorealg_Geometry
                            art_Framework_Principal
                            art_Persistency_Provenance
                            ${MF_MESSAGELOGGER}
-                           ${ROOT_CORE}
+                           ROOT::Core
          MODULE_LIBRARIES larcorealg_Geometry
                           art_Framework_Services_Registry
                           ${MF_MESSAGELOGGER}
-                          ${ROOT_CORE}
-                          ${ROOT_GEOM}
-                          ${ROOT_GENVECTOR})
+                          ROOT::Core
+                          ROOT::Geom
+                          ROOT::GenVector)
 
 install_headers()
 install_fhicl()

--- a/larcore/Geometry/Geometry.h
+++ b/larcore/Geometry/Geometry.h
@@ -145,6 +145,6 @@ namespace geo {
 
 } // namespace geo
 
-DECLARE_ART_SERVICE(geo::Geometry, LEGACY)
+DECLARE_ART_SERVICE(geo::Geometry, SHARED)
 
 #endif // GEO_GEOMETRY_H

--- a/larcore/Geometry/Geometry.h
+++ b/larcore/Geometry/Geometry.h
@@ -116,14 +116,14 @@ namespace geo {
 
     Geometry(fhicl::ParameterSet const& pset, art::ActivityRegistry& reg);
 
-    /// Updates the geometry if needed at the beginning of each new run
-    void preBeginRun(art::Run const& run);
-
     /// Returns a pointer to the geometry service provider
     provider_type const* provider() const
       { return static_cast<provider_type const*>(this); }
 
   private:
+
+    /// Updates the geometry if needed at the beginning of each new run
+    void preBeginRun(art::Run const& run);
 
     /// Expands the provided paths and loads the geometry description(s)
     void LoadNewGeometry(
@@ -140,17 +140,11 @@ namespace geo {
     bool                      fForceUseFCLOnly;  ///< Force Geometry to only use the geometry
                                                  ///< files specified in the fcl file
     fhicl::ParameterSet       fSortingParameters;///< Parameter set to define the channel map sorting
-
     fhicl::ParameterSet       fBuilderParameters;///< Parameter set for geometry builder.
-
   };
 
 } // namespace geo
 
 DECLARE_ART_SERVICE(geo::Geometry, LEGACY)
-
-// check that the requirements for geo::Geometry are satisfied
-template struct lar::details::ServiceRequirementsChecker<geo::Geometry>;
-
 
 #endif // GEO_GEOMETRY_H

--- a/larcore/Geometry/Geometry_service.cc
+++ b/larcore/Geometry/Geometry_service.cc
@@ -78,7 +78,7 @@ namespace geo {
     }
 
     // if the detector name is still the same, everything is fine
-    std::string newDetectorName = rdcol.front()->DetName();
+    auto const& newDetectorName = rdcol.front()->DetName();
     if (DetectorName() == newDetectorName) return;
 
     // check to see if the detector name in the RunData
@@ -92,7 +92,7 @@ namespace geo {
       SetDetectorName(newDetectorName);
     }
 
-    LoadNewGeometry(DetectorName() + ".gdml", DetectorName() + ".gdml", true);
+    LoadNewGeometry(newDetectorName + ".gdml", newDetectorName + ".gdml", true);
   } // Geometry::preBeginRun()
 
 
@@ -101,14 +101,14 @@ namespace geo {
   {
     // the channel map is responsible of calling the channel map configuration
     // of the geometry
-    art::ServiceHandle<geo::ExptGeoHelperInterface>()
-      ->ConfigureChannelMapAlg(fSortingParameters, this);
-
-    if ( ! ChannelMap() ) {
+    art::ServiceHandle<geo::ExptGeoHelperInterface const> helper{};
+    auto channelMapAlg = helper->ConfigureChannelMapAlg(fSortingParameters,
+                                                        DetectorName());
+    if (!channelMapAlg) {
       throw cet::exception("ChannelMapLoadFail")
         << " failed to load new channel map";
     }
-
+    ApplyChannelMap(move(channelMapAlg));
   } // Geometry::InitializeChannelMap()
 
   //......................................................................
@@ -131,7 +131,7 @@ namespace geo {
     // the detector geometry.
     // cet::search_path constructor decides if initialized value is a path
     // or an environment variable
-    cet::search_path sp("FW_SEARCH_PATH");
+    cet::search_path const sp{"FW_SEARCH_PATH"};
 
     std::string GDMLfile;
     if( !sp.find_file(GDMLFileName, GDMLfile) ) {
@@ -149,17 +149,13 @@ namespace geo {
         << "\nbail ungracefully.\n";
     }
 
-    std::unique_ptr<geo::GeometryBuilder> builder
-      = std::make_unique<geo::GeometryBuilderStandard>(
-        fhicl::Table<geo::GeometryBuilderStandard::Config>
-        (fBuilderParameters, { "tool_type" })
-        ()
-      );
+    {
+      fhicl::Table<geo::GeometryBuilderStandard::Config> const config{fBuilderParameters, {"tool_type"}};
+      geo::GeometryBuilderStandard builder{config()};
 
-    // initialize the geometry with the files we have found
-    LoadGeometryFile(GDMLfile, ROOTfile, *builder, bForceReload);
-
-    builder.release(); // done with it: release immediately
+      // initialize the geometry with the files we have found
+      LoadGeometryFile(GDMLfile, ROOTfile, builder, bForceReload);
+    }
 
     // now update the channel map
     InitializeChannelMap();

--- a/larcore/Geometry/Geometry_service.cc
+++ b/larcore/Geometry/Geometry_service.cc
@@ -22,9 +22,10 @@
 // C/C++ standard libraries
 #include <string>
 
+// check that the requirements for geo::Geometry are satisfied
+template struct lar::details::ServiceRequirementsChecker<geo::Geometry>;
 
 namespace geo {
-
 
   //......................................................................
   // Constructor.

--- a/larcore/Geometry/StandardGeometryHelper.h
+++ b/larcore/Geometry/StandardGeometryHelper.h
@@ -17,8 +17,6 @@
 // C/C++ standard libraries
 #include <memory> // std::shared_ptr<>
 
-// Declaration
-//
 namespace geo
 {
   /**
@@ -27,42 +25,20 @@ namespace geo
    * This ExptGeoHelperInterface implementation serves a ChannelMapStandardAlg
    * for experiments that are known to work well with it.
    */
-  class StandardGeometryHelper : public ExptGeoHelperInterface
-  {
+  class StandardGeometryHelper : public ExptGeoHelperInterface {
   public:
-
-    /// Constructor; follows the standard art service signature
-    StandardGeometryHelper(fhicl::ParameterSet const & pset);
-
-    /*
-      Public interface for ExptGeoHelperInterface (for reference purposes)
-
-      Configure, initialize and return the channel map:
-
-      void ConfigureChannelMapAlg
-        (fhicl::ParameterSet const& sortingParameters, geo::GeometryCore* geom);
-
-      Returns null pointer if the initialization failed:
-
-      ChannelMapAlgPtr_t GetChannelMapAlg() const;
-    */
+    explicit StandardGeometryHelper(fhicl::ParameterSet const& pset);
 
   private:
-
-    virtual void doConfigureChannelMapAlg
-      (fhicl::ParameterSet const& sortingParameters, geo::GeometryCore* geom)
-      override;
-    virtual ChannelMapAlgPtr_t doGetChannelMapAlg() const override;
-
-
-    fhicl::ParameterSet fPset; ///< copy of configuration parameter set
-    std::shared_ptr<geo::ChannelMapAlg> fChannelMap; ///< channel map algorithm
-
+    ChannelMapAlgPtr_t
+    doConfigureChannelMapAlg(fhicl::ParameterSet const& sortingParameters,
+                             std::string const& detectorName) const override;
   };
 
 }
-DECLARE_ART_SERVICE_INTERFACE_IMPL(
-  geo::StandardGeometryHelper, geo::ExptGeoHelperInterface, LEGACY
-  )
+
+DECLARE_ART_SERVICE_INTERFACE_IMPL(geo::StandardGeometryHelper,
+                                   geo::ExptGeoHelperInterface,
+                                   SHARED)
 
 #endif // GEO_StandardGeometryHelper_h

--- a/larcore/Geometry/StandardGeometryHelper_service.cc
+++ b/larcore/Geometry/StandardGeometryHelper_service.cc
@@ -14,41 +14,24 @@
 // framework libraries
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
-
 namespace geo
 {
 
   //----------------------------------------------------------------------------
-  StandardGeometryHelper::StandardGeometryHelper(fhicl::ParameterSet const& pset)
-    : fPset( pset )
-    , fChannelMap()
-    {}
-
-
-  //----------------------------------------------------------------------------
-  void StandardGeometryHelper::doConfigureChannelMapAlg
-    (fhicl::ParameterSet const& sortingParameters, geo::GeometryCore* geom)
-  {
-    mf::LogInfo("StandardGeometryHelper")
-      << "Loading channel mapping: ChannelMapStandardAlg";
-    fChannelMap
-      = std::make_shared<geo::ChannelMapStandardAlg>(sortingParameters);
-    geom->ApplyChannelMap(fChannelMap);
-
-  } // StandardGeometryHelper::doConfigureChannelMapAlg()
-
+  StandardGeometryHelper::StandardGeometryHelper(fhicl::ParameterSet const&)
+  {}
 
   //----------------------------------------------------------------------------
   StandardGeometryHelper::ChannelMapAlgPtr_t
-  StandardGeometryHelper::doGetChannelMapAlg() const
+  StandardGeometryHelper::doConfigureChannelMapAlg(fhicl::ParameterSet const& sortingParameters,
+                                                   std::string const& /*detectorName*/) const
   {
-    return fChannelMap;
+    mf::LogInfo("StandardGeometryHelper")
+      << "Loading channel mapping: ChannelMapStandardAlg";
+    return std::make_unique<geo::ChannelMapStandardAlg>(sortingParameters);
   }
-
-  //----------------------------------------------------------------------------
 
 } // namespace geo
 
-DEFINE_ART_SERVICE_INTERFACE_IMPL(
-  geo::StandardGeometryHelper, geo::ExptGeoHelperInterface
-  )
+DEFINE_ART_SERVICE_INTERFACE_IMPL(geo::StandardGeometryHelper,
+                                  geo::ExptGeoHelperInterface)


### PR DESCRIPTION
This is part of a coordinated set of PRs that accomplish two tasks:

- Switching to geometry collections that own by value instead of by pointer
- Switching the (AuxDet) geometry systems to be thread-safe within a run

In addition, there is a new class added called `lar::EnsureOnlyOneThread`, which ensures that only one *art* schedule has been enabled when using any class that inherits from it.

There are breaking changes associated with this PR, and they will be presented at the next LArSoft coordination meeting.