### PR TITLE
Geometry configuration check (issue #24328) [1/10]

### DIFF
--- a/larcore/Geometry/CMakeLists.txt
+++ b/larcore/Geometry/CMakeLists.txt
@@ -1,5 +1,8 @@
 art_make(SERVICE_LIBRARIES larcorealg_Geometry
+                           larcoreobj_SummaryData
+                           art_Framework_Services_Registry
                            art_Framework_Principal
+                           art_Framework_Core
                            art_Persistency_Provenance
                            ${MF_MESSAGELOGGER}
                            ROOT::Core

--- a/larcore/Geometry/Geometry.h
+++ b/larcore/Geometry/Geometry.h
@@ -171,7 +171,7 @@ namespace geo {
    * this happens _before_ the `Geometry` service itself is notified by _art_
    * of the start of the new run.
    * If some `geo::GeometryConfigurationWriter` information is already in the
-   * run record, `geo::GeometryConfigurationWriter` performs no action.
+   * run record, `geo::GeometryConfigurationWriter` replicates it again.
    * As legacy check, if there is no information in the
    * `sumdata::GeometryConfigurationInfo` form but there is a `sumdata::RunData`
    * data product, the latter is used as a base for the check.

--- a/larcore/Geometry/Geometry.h
+++ b/larcore/Geometry/Geometry.h
@@ -225,7 +225,7 @@ namespace geo {
     /// @{
     
     /// Fills the service configuration information into `fConfInfo`.
-    void FillGeomeryConfigurationInfo(fhicl::ParameterSet const& config);
+    void FillGeometryConfigurationInfo(fhicl::ParameterSet const& config);
     
     /// Returns if the `other` configuration is compatible with our current.
     bool CheckConfigurationInfo

--- a/larcore/Geometry/Geometry.h
+++ b/larcore/Geometry/Geometry.h
@@ -1,8 +1,8 @@
 /**
- * @file   Geometry.h
+ * @file   larcore/Geometry/Geometry.h
  * @brief  art framework interface to geometry description
  * @author brebel@fnal.gov
- * @see    Geometry_service.cc
+ * @see    larcore/Geometry/Geometry_service.cc
  *
  * Revised <seligman@nevis.columbia.edu> 29-Jan-2009
  *         Revise the class to make it into more of a general detector interface
@@ -13,12 +13,13 @@
  *         Complying with the provider requirements described in ServiceUtil.h
  */
 
-#ifndef GEO_GEOMETRY_H
-#define GEO_GEOMETRY_H
+#ifndef LARCORE_GEOMETRY_GEOMETRY_H
+#define LARCORE_GEOMETRY_GEOMETRY_H
 
 // LArSoft libraries
-#include "larcorealg/Geometry/GeometryCore.h"
 #include "larcore/CoreUtils/ServiceUtil.h" // not used; for user's convenience
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcoreobj/SummaryData/GeometryConfigurationInfo.h"
 
 // the following are included for convenience only
 #include "larcorealg/Geometry/ChannelMapAlg.h"
@@ -86,13 +87,9 @@ namespace geo {
    *   with an alternative geometry from a file with the standard name as
    *   configured with the /GDML/ parameter, but with an additional "_nowires"
    *   appended before the ".gdml" suffix
-   * - *ForceUseFCLOnly* (boolean, default: false): information on the current
-   *   geometry is stored in each run by the event generator producers; if this
-   *   information does not describe the current geometry, a new geometry is
-   *   loaded according to the information in the run. If `ForceUseFCLOnly`
-   *   is set to `true`, this mechanism is disabled and the geometry is just
-   *   loaded at the beginning of the job from the information in the job
-   *   configuration, once and for all.
+   * - *SkipConfigurationCheck* (boolean, default: `false`): if set to `true`,
+   *   failure of configuration consistency check described below is not fatal
+   *   and it will just produce a warning on each failure;
    * - *SortingParameters* (a parameter set; default: empty): this configuration
    *   is directly passed to the channel mapping algorithm (see
    *   geo::ChannelMapAlg); its content is dependent on the chosen
@@ -107,6 +104,94 @@ namespace geo {
    * @note Currently, the file defined by `GDML` parameter is also served to
    * ROOT for the internal geometry representation.
    *
+   *
+   *
+   * Configuration consistency check
+   * ================================
+   * 
+   * The `Geometry` service checks that the input files were processed with a
+   * configuration of `Geometry` service compatible with the current one.
+   * 
+   * Two checks may be performed: the standard check, and a legacy check.
+   * 
+   * 
+   * Consistency check
+   * ------------------
+   * 
+   * The `Geometry` service checks at the beginning of each run that the
+   * current configuration is compatible with the geometry configuration
+   * declared in the input file.
+   * The `Geometry` service requires that an additional service,
+   * `GeometryConfigurationWriter`, is run: this service is charged with writing
+   * the configuration information into the output files, for the checks in
+   * the future job.
+   * 
+   * The compatibility check is currently very silly, but it can improved in
+   * future versions. This check is the same as the legacy check, that verifies
+   * that the configured detector name (`geo::GeometryCore::DetectorName()`)
+   * has not changed.
+   * 
+   * To allow this check to operate correctly, the only requirement is that
+   * the service `GeometryConfigurationWriter` be included in the job:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * services.GeometryConfigurationWriter: {}
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * This must happen on the first job in the processing chain that configures
+   * `Geometry` service. It is irrelevant, but not harmful, in the jobs that
+   * follow.
+   * 
+   * 
+   * ### Design details
+   * 
+   * This section describes the full design of the check from a technical point
+   * of view. Users do not need to understand the mechanisms of this check in
+   * order to configure their jobs to successfully pass it.
+   * 
+   * The check happens based on the data contained in the
+   * `sumdata::GeometryConfigurationInfo` data product.
+   * Starting from after the construction is complete, `geo::Geometry` is able
+   * to provide at any time an instance of `sumdata::GeometryConfigurationInfo`
+   * describing the geometry configuration for this job, whether the geometry
+   * is already configured or not.
+   * 
+   * The `Geometry` service loads the geometry at the beginning of the job.
+   * At the start of each run from the input file, the `Geometry` service
+   * reads a configuration information `sumdata::GeometryConfigurationInfo` from
+   * the `art::Run` record and verifies that it is compatible with the current
+   * configuration. It is a fatal error for this information not to be available
+   * in `art::Run`, and it is a fatal check failure if the available
+   * information is not compatible with the current configuration.
+   * 
+   * The `sumdata::GeometryConfigurationInfo` information is put into `art::Run`
+   * record by the `geo::GeometryConfigurationWriter` producing service.
+   * This service verifies whether there is already such information in the run.
+   * If no information is available yet in `art::Run`, the service obtains the
+   * current configuration information from the `Geometry` service, and then
+   * puts it into the `art::Run` record. The _art_ framework guarantees that
+   * this happens _before_ the `Geometry` service itself is notified by _art_
+   * of the start of the new run.
+   * If some `geo::GeometryConfigurationWriter` information is already in the
+   * run record, `geo::GeometryConfigurationWriter` performs no action.
+   * As legacy check, if there is no information in the
+   * `sumdata::GeometryConfigurationInfo` form but there is a `sumdata::RunData`
+   * data product, the latter is used as a base for the check.
+   * 
+   * 
+   * Design notes:
+   * 
+   * * the choice of delegating the writing of data product to a producing
+   *   service rather than to modules is driven by the fact that there is a way
+   *   to enforce this service to be actually run, and that no further
+   *   instrumentation is needed;
+   * * the choice of putting the configuration information in the `art::Run` is
+   *   driven by the fact that the run is the highest available container;
+   *   job-level data products (`art::Results`) behave very differently from
+   *   the others and are not currently interfaced with a producing service;
+   * * the information in `sumdata::GeometryConfigurationInfo` should be compact
+   *   enough not to bloat the data files with very few events per run, as it
+   *   may be for the selection of rare processes or signatures.
+   * 
+   *
    */
   class Geometry: public GeometryCore
   {
@@ -120,6 +205,10 @@ namespace geo {
     provider_type const* provider() const
       { return static_cast<provider_type const*>(this); }
 
+    /// Returns the current geometry configuration information.
+    sumdata::GeometryConfigurationInfo const& configurationInfo() const
+      { return fConfInfo; }
+    
   private:
 
     /// Updates the geometry if needed at the beginning of each new run
@@ -131,20 +220,47 @@ namespace geo {
       bool bForceReload = false
       );
 
+    // --- BEGIN -- Configuration information checks ---------------------------
+    /// @name Configuration information checks
+    /// @{
+    
+    /// Fills the service configuration information into `fConfInfo`.
+    void FillGeomeryConfigurationInfo(fhicl::ParameterSet const& config);
+    
+    /// Returns if the `other` configuration is compatible with our current.
+    bool CheckConfigurationInfo
+      (sumdata::GeometryConfigurationInfo const& other) const;
+    
+    /// Reads and returns the geometry configuration information from the run.
+    static sumdata::GeometryConfigurationInfo const& ReadConfigurationInfo
+      (art::Run const& run);
+    
+    /// Returns if `A` and `B` are compatible geometry service configurations.
+    static bool CompareConfigurationInfo(
+      sumdata::GeometryConfigurationInfo const& A,
+      sumdata::GeometryConfigurationInfo const& B
+      );
+    
+    /// @}
+    // --- END -- Configuration information checks -----------------------------
+    
     void InitializeChannelMap();
 
     std::string               fRelPath;          ///< Relative path added to FW_SEARCH_PATH to search for
                                                  ///< geometry file
     bool                      fDisableWiresInG4; ///< If set true, supply G4 with GDMLfileNoWires
                                                  ///< rather than GDMLfile
-    bool                      fForceUseFCLOnly;  ///< Force Geometry to only use the geometry
+    bool                      fNonFatalConfCheck;///< Don't stop if configuration check fails.
                                                  ///< files specified in the fcl file
     fhicl::ParameterSet       fSortingParameters;///< Parameter set to define the channel map sorting
     fhicl::ParameterSet       fBuilderParameters;///< Parameter set for geometry builder.
+    
+    sumdata::GeometryConfigurationInfo fConfInfo;///< Summary of service configuration.
+    
   };
 
 } // namespace geo
 
 DECLARE_ART_SERVICE(geo::Geometry, SHARED)
 
-#endif // GEO_GEOMETRY_H
+#endif // LARCORE_GEOMETRY_GEOMETRY_H

--- a/larcore/Geometry/GeometryConfigurationWriter_service.cc
+++ b/larcore/Geometry/GeometryConfigurationWriter_service.cc
@@ -92,16 +92,14 @@ class geo::GeometryConfigurationWriter: public art::ProducingService {
   
     private:
   
-  /// Alias for the pointer to the data product object to be put into the run.
-  using InfoPtr_t = std::unique_ptr<sumdata::GeometryConfigurationInfo>;
-  
-  
-  // -- BEGIN --- Interface ----------------------------------------------------
-      
   /// Writes the information from the service configuration into the `run`.
   virtual void postReadRun(art::Run& run) override;
   
-  // -- END --- Interface ------------------------------------------------------
+  
+    private:
+  
+  /// Alias for the pointer to the data product object to be put into the run.
+  using InfoPtr_t = std::unique_ptr<sumdata::GeometryConfigurationInfo>;
   
   
   /// Loads the geometry information from the `run` (either directly or legacy).
@@ -124,13 +122,9 @@ class geo::GeometryConfigurationWriter: public art::ProducingService {
   static InfoPtr_t convertRunDataToGeometryInformation
     (sumdata::RunData const& data);
   
-  /// Alias to `std::make_unique<sumdata::GeometryConfigurationInfo>`
-  template <typename... Args>
-  static InfoPtr_t makeInfoPtr(Args&&... args)
-    {
-      return std::make_unique<sumdata::GeometryConfigurationInfo>
-        (std::forward<Args>(args)...);
-    }
+  /// Alias to `std::make_unique<sumdata::GeometryConfigurationInfo>`.
+  static InfoPtr_t makeInfoPtr(sumdata::GeometryConfigurationInfo const& info)
+    { return std::make_unique<sumdata::GeometryConfigurationInfo>(info); }
   
   
 }; // geo::GeometryConfigurationWriter

--- a/larcore/Geometry/GeometryConfigurationWriter_service.cc
+++ b/larcore/Geometry/GeometryConfigurationWriter_service.cc
@@ -1,0 +1,215 @@
+/**
+ * @file   larcore/Geometry/GeometryConfigurationWriter_service.cc
+ * @brief  Service writing geometry configuration information into _art_ runs.
+ * @date   October 7, 2020
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ *
+ * Producing services have no header.
+ */
+
+// LArSoft libraries
+#include "larcore/Geometry/Geometry.h"
+#include "larcoreobj/SummaryData/GeometryConfigurationInfo.h"
+#include "larcoreobj/SummaryData/RunData.h"
+
+// framework libraries
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Framework/Core/ProducingService.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/Handle.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+// C/C++ standard libraries
+#include <memory> // std::make_unique()
+
+
+// -----------------------------------------------------------------------------
+namespace geo { class GeometryConfigurationWriter; }
+/**
+ * @brief Writes geometry configuration information into _art_ runs.
+ * 
+ * This service is part of the mandatory version check of `geo::Geometry`
+ * service.
+ * It does not require any special configuration, but it must be listed
+ * in the configuration in order for `Geometry` to work:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * services: {
+ *   
+ *   GeometryConfigurationWriter: {}
+ *   
+ *   Geometry: @local::experiment_geometry
+ *   
+ *   # ...
+ *  
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * The configuration check is described in the documentation of `geo::Geometry`
+ * service.
+ * 
+ * 
+ * Produced data products
+ * -----------------------
+ * 
+ * The service guarantees that configuration information of type
+ * `sumdata::GeometryConfigurationInfo` is present into the run, accessible with
+ * an input tag `GeometryConfigurationWriter`:
+ * 
+ * * if such information is already available in the run, no further information
+ *   is added
+ * * legacy: if there is no such information, but there is a `sumdata::RunData`
+ *   data product, a reduced version of the configuration information is created
+ *   from the information in that data product (the first one, if multiple are
+ *   present)
+ * * finally, if no information is present neither in the full 
+ *   `sumdata::GeometryConfigurationInfo` form nor in the legacy
+ *   `sumdata::RunData` form, information is put together based on the current
+ *   configuration of the `Geometry` service.
+ * 
+ * 
+ * Service dependencies
+ * ---------------------
+ * 
+ * * `Geometry` service
+ *   (for obtaining the current configuration to put into the event)
+ * 
+ */
+class geo::GeometryConfigurationWriter: public art::ProducingService {
+  
+    public:
+  
+  /// Service configuration.
+  struct Config {
+    // no configuration parameters at this time
+  };
+  
+  using Parameters = art::ServiceTable<Config>;
+  
+  /// Constructor: gets its configuration and does nothing with it.
+  GeometryConfigurationWriter(Parameters const&);
+  
+  
+    private:
+  
+  // -- BEGIN --- Interface ----------------------------------------------------
+      
+  /// Writes the information from the service configuration into the `run`.
+  virtual void postReadRun(art::Run& run) override;
+  
+  // -- END --- Interface ------------------------------------------------------
+  
+  
+  /// Writes the information from the service configuration into the `run`.
+  void writeGeometryInformation(art::Run& run) const;
+  
+  /// Writes geometry information made up from the current run data.
+  void writeGeometryInformationFromRunData
+    (art::Run& run, sumdata::RunData const& data) const;
+  
+  /// Returns if there is already geometry configuration information in `run`.
+  bool hasGeometryInformation(art::Run& run) const;
+  
+  /// Returns the first of the `sumdata::RunData` information records in `run`.
+  sumdata::RunData const* readRunData(art::Run& run) const;
+  
+  /// Puts the specified configuration information into the `run`.
+  void putGeometryInformationIntoRun
+    (art::Run& run, sumdata::GeometryConfigurationInfo confInfo) const;
+  
+}; // geo::GeometryConfigurationWriter
+
+
+// -----------------------------------------------------------------------------
+// --- implementation
+// -----------------------------------------------------------------------------
+geo::GeometryConfigurationWriter::GeometryConfigurationWriter(Parameters const&)
+{
+  produces<sumdata::GeometryConfigurationInfo, art::InRun>();
+}
+
+
+// -----------------------------------------------------------------------------
+void geo::GeometryConfigurationWriter::postReadRun(art::Run& run) {
+  
+  if (!hasGeometryInformation(run)) {
+    sumdata::RunData const* runData = readRunData(run);
+    if (runData) writeGeometryInformationFromRunData(run, *runData);
+    else writeGeometryInformation(run);
+  }
+  
+} // geo::GeometryConfigurationWriter::postReadRun()
+
+
+// -----------------------------------------------------------------------------
+void geo::GeometryConfigurationWriter::writeGeometryInformation
+  (art::Run& run) const
+{
+  
+  sumdata::GeometryConfigurationInfo const& confInfo
+    = art::ServiceHandle<geo::Geometry>()->configurationInfo();
+  
+  MF_LOG_DEBUG("GeometryConfigurationWriter")
+    << "Writing geometry configuration information:\n" << confInfo;
+  
+  putGeometryInformationIntoRun(run, std::move(confInfo));
+  
+} // geo::GeometryConfigurationWriter::writeGeometryInformation()
+
+
+// -----------------------------------------------------------------------------
+void geo::GeometryConfigurationWriter::writeGeometryInformationFromRunData
+  (art::Run& run, sumdata::RunData const& data) const
+{
+  
+  // we use the simplest version 1 data format
+  sumdata::GeometryConfigurationInfo confInfo;
+  confInfo.dataVersion = sumdata::GeometryConfigurationInfo::DataVersion_t{1};
+  confInfo.detectorName = data.DetName();
+  confInfo.geometryServiceConfiguration = "{}";
+  
+  MF_LOG_DEBUG("GeometryConfigurationInfo")
+   << "Writing geometry configuration information from run data:\n" << confInfo;
+  
+  putGeometryInformationIntoRun(run, std::move(confInfo));
+  
+} // geo::GeometryConfigurationWriter::writeGeometryInformationFromRunData()
+
+
+// -----------------------------------------------------------------------------
+void geo::GeometryConfigurationWriter::putGeometryInformationIntoRun
+  (art::Run& run, sumdata::GeometryConfigurationInfo confInfo) const
+{
+  run.put(
+    std::make_unique<sumdata::GeometryConfigurationInfo>(std::move(confInfo)),
+    art::fullRun()
+    );
+} // geo::GeometryConfigurationWriter::putGeometryInformationIntoRun()
+
+
+// -----------------------------------------------------------------------------
+bool geo::GeometryConfigurationWriter::hasGeometryInformation
+  (art::Run& run) const
+{
+  
+  art::Handle<sumdata::GeometryConfigurationInfo> h;
+  return run.getByLabel(art::InputTag{"GeometryConfigurationWriter"}, h);
+  
+} // geo::GeometryConfigurationWriter::hasGeometryInformation()
+
+
+// -----------------------------------------------------------------------------
+sumdata::RunData const* geo::GeometryConfigurationWriter::readRunData
+  (art::Run& run) const
+{
+  std::vector<art::Handle<sumdata::RunData>> allRunData;
+  run.getManyByType(allRunData);
+  return allRunData.empty()? nullptr: allRunData.front().product();
+} // geo::GeometryConfigurationWriter::readRunData()
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_PRODUCING_SERVICE(geo::GeometryConfigurationWriter)
+
+
+// -----------------------------------------------------------------------------

--- a/larcore/Geometry/GeometryConfigurationWriter_service.cc
+++ b/larcore/Geometry/GeometryConfigurationWriter_service.cc
@@ -234,10 +234,9 @@ auto geo::GeometryConfigurationWriter::convertRunDataToGeometryInformation
   
   sumdata::GeometryConfigurationInfo confInfo;
   
-  // we use the simplest version 1 data format
+  // we use the simplest version 1 data format (legacy format)
   confInfo.dataVersion = sumdata::GeometryConfigurationInfo::DataVersion_t{1};
   confInfo.detectorName = data.DetName();
-  confInfo.geometryServiceConfiguration = "{}";
   
   MF_LOG_DEBUG("GeometryConfigurationInfo")
    << "Built geometry configuration information from run data:\n" << confInfo;

--- a/larcore/Geometry/Geometry_service.cc
+++ b/larcore/Geometry/Geometry_service.cc
@@ -10,7 +10,6 @@
 
 // lar includes
 #include "larcorealg/Geometry/GeometryBuilderStandard.h"
-#include "larcoreobj/SummaryData/RunData.h"
 #include "larcore/Geometry/ExptGeoHelperInterface.h"
 
 // Framework includes
@@ -67,7 +66,7 @@ namespace geo {
     // load the geometry
     LoadNewGeometry(GDMLFileName, ROOTFileName);
     
-    FillGeomeryConfigurationInfo(pset);
+    FillGeometryConfigurationInfo(pset);
 
   } // Geometry::Geometry()
 
@@ -166,7 +165,8 @@ namespace geo {
   } // Geometry::LoadNewGeometry()
 
   //......................................................................
-  void Geometry::FillGeomeryConfigurationInfo(fhicl::ParameterSet const& config)
+  void Geometry::FillGeometryConfigurationInfo
+    (fhicl::ParameterSet const& config)
   {
     
     sumdata::GeometryConfigurationInfo confInfo;
@@ -182,7 +182,7 @@ namespace geo {
     MF_LOG_TRACE("Geometry")
       << "Geometry configuration information:\n" << fConfInfo;
     
-  } // Geometry::FillGeomeryConfigurationInfo()
+  } // Geometry::FillGeometryConfigurationInfo()
 
   //......................................................................
   bool Geometry::CheckConfigurationInfo

--- a/larcore/Geometry/Geometry_service.cc
+++ b/larcore/Geometry/Geometry_service.cc
@@ -170,12 +170,12 @@ namespace geo {
   {
     
     sumdata::GeometryConfigurationInfo confInfo;
-    confInfo.dataVersion = sumdata::GeometryConfigurationInfo::DataVersion_t{1};
+    confInfo.dataVersion = sumdata::GeometryConfigurationInfo::DataVersion_t{2};
     
-    // version 1:
+    // version 1+:
     confInfo.detectorName = DetectorName();
     
-    // all versions
+    // version 2+:
     confInfo.geometryServiceConfiguration = config.to_indented_string();
     fConfInfo = std::move(confInfo);
     

--- a/larcore/Geometry/geometry_bo.fcl
+++ b/larcore/Geometry/geometry_bo.fcl
@@ -13,4 +13,10 @@ bo_geometry_helper:
  service_provider : StandardGeometryHelper
 }
 
+bo_geometry_services: {
+  GeometryConfigurationWriter: {}
+  Geometry:                    @local::bo_geo
+  ExptGeoInterfaceHelper:      @local::bo_geometry_helper
+}
+
 END_PROLOG

--- a/test/Geometry/CMakeLists.txt
+++ b/test/Geometry/CMakeLists.txt
@@ -1,5 +1,7 @@
 cet_enable_asserts()
 
+add_subdirectory(VersionCheck)
+
 # test modules
 simple_plugin ( GeometryIteratorLoopTest "module"
                     larcorealg_Geometry
@@ -22,6 +24,7 @@ simple_plugin ( GeometryTest "module"
                     ${ROOT_BASIC_LIB_LIST}
               )
 
+# ------------------------------------------------------------------------------
 # geometry test on "standard" geometry
 
 # This test is equivalent to geometry_test, but run in art environment
@@ -51,7 +54,8 @@ cet_test(dump_channel_map_test HANDBUILT
   DATAFILES dump_lartpcdetector_channelmap.fcl
 )
 
-
+# ------------------------------------------------------------------------------
 install_headers()
 install_fhicl()
 install_source()
+

--- a/test/Geometry/VersionCheck/CMakeLists.txt
+++ b/test/Geometry/VersionCheck/CMakeLists.txt
@@ -29,7 +29,7 @@ cet_test(GeometryInfoCheckEmptyInput HANDBUILT
 # but not the new GeometryConfigurationWriter service;
 # expected: `ProductNotFound` exception
 
-cet_test(q HANDBUILT
+cet_test(GeometryInfoCheckNoWriter HANDBUILT
   TEST_EXEC lar
   TEST_ARGS --rethrow-all --config ./test_geometry_check_nogeoconfwriter.fcl
   DATAFILES

--- a/test/Geometry/VersionCheck/CMakeLists.txt
+++ b/test/Geometry/VersionCheck/CMakeLists.txt
@@ -1,0 +1,164 @@
+cet_enable_asserts()
+
+# test modules
+simple_plugin ( GeometryInfoCheck "module"
+  larcore_Geometry_Geometry_service
+  larcorealg_Geometry
+  )
+
+simple_plugin ( LegacyGeometryInfoWriter "module"
+  larcoreobj_SummaryData
+  )
+
+# ------------------------------------------------------------------------------
+
+# no input file (source: EmptyEvent)
+# expected: geometry information added to output file
+#   (check is performed by an analyzer at begin run)
+
+cet_test(GeometryInfoCheckEmptyInput HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS
+    --rethrow-all --config ./test_geometry_check_empty.fcl
+    --output data_withGeometryA.root
+  DATAFILES test_geometries.fcl test_geometry_checks.fcl test_geometry_check_empty.fcl
+)
+
+
+# no input file, with a job including Geometry service
+# but not the new GeometryConfigurationWriter service;
+# expected: configuration error
+
+cet_test(GeometryInfoCheckNoWriter HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS --rethrow-all --config ./test_geometry_check_nogeoconfwriter.fcl
+  DATAFILES test_geometries.fcl test_geometry_checks.fcl test_geometry_check_nogeoconfwriter.fcl
+  TEST_PROPERTIES
+    DEPENDS GeometryInfoCheckEmptyInput
+    WILL_FAIL TRUE
+)
+
+
+# input file with sumdata::RunData data product compatible with current Geometry
+# expected: geometry information added to output file
+
+cet_test(GeometryInfoCheckMakeLegacyInput HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS
+    --rethrow-all
+    --config ./test_geometry_check_make_legacy_input.fcl
+    --output data_withGeometryA_legacy.root
+  DATAFILES
+    test_geometries.fcl
+    test_geometry_check_make_legacy_input.fcl
+)
+
+cet_test(GeometryInfoCheckLegacyCompatible HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS
+    --rethrow-all
+    --config ./test_geometry_check_require_geometryA.fcl
+    --source ../GeometryInfoCheckMakeLegacyInput.d/data_withGeometryA_legacy.root
+  DATAFILES
+    test_geometries.fcl test_geometry_checks.fcl
+    test_geometry_check_require_geometryA.fcl
+  TEST_PROPERTIES
+    DEPENDS GeometryInfoCheckMakeLegacyInput
+)
+
+
+# input file with sumdata::RunData data product not compatible with current Geometry
+# exception: exception showing the different configurations
+
+cet_test(GeometryInfoCheckLegacyIncompatible HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS
+    --rethrow-all
+    --config ./test_geometry_check_require_geometryB.fcl
+    --source ../GeometryInfoCheckMakeLegacyInput.d/data_withGeometryA_legacy.root
+  DATAFILES
+    test_geometries.fcl test_geometry_checks.fcl
+    test_geometry_check_require_geometryB.fcl
+  TEST_PROPERTIES
+    DEPENDS GeometryInfoCheckMakeLegacyInput
+    WILL_FAIL TRUE
+)
+
+
+# input file with sumdata::GeometryConfigurationInfo data product
+# compatible with current Geometry
+# expected: data product declared but not put, all seems ok
+
+cet_test(GeometryInfoCheckCompatible HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS
+    --rethrow-all
+    --config ./test_geometry_check_require_geometryA.fcl
+    --source ../GeometryInfoCheckEmptyInput.d/data_withGeometryA.root
+    --output data_withGeometryA_OnceMore.root
+  DATAFILES
+    test_geometries.fcl test_geometry_checks.fcl
+    test_geometry_check_require_geometryA.fcl
+  TEST_PROPERTIES
+    DEPENDS GeometryInfoCheckEmptyInput
+)
+
+
+# input file with sumdata::GeometryConfigurationInfo data product
+# not compatible with current Geometry
+# expected: exception showing the different configurations
+
+cet_test(GeometryInfoCheckIncompatible HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS
+    --rethrow-all
+    --config ./test_geometry_check_require_geometryB.fcl
+    --source ../GeometryInfoCheckEmptyInput.d/data_withGeometryA.root
+  DATAFILES
+    test_geometries.fcl test_geometry_checks.fcl
+    test_geometry_check_require_geometryB.fcl
+  TEST_PROPERTIES
+    DEPENDS GeometryInfoCheckEmptyInput
+    WILL_FAIL TRUE
+)
+
+
+# input file with sumdata::GeometryConfigurationInfo data product
+# not compatible with current Geometry; Geometry configuration skips the check
+# expected: pass (with warning)
+
+cet_test(GeometryInfoCheckIncompatibleSkipCheck HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS
+    --rethrow-all
+    --config ./test_geometry_check_geometryB_skipCheck.fcl
+    --source ../GeometryInfoCheckEmptyInput.d/data_withGeometryA.root
+  DATAFILES
+    test_geometries.fcl test_geometry_checks.fcl
+    test_geometry_check_geometryB_skipCheck.fcl
+  TEST_PROPERTIES
+    DEPENDS GeometryInfoCheckEmptyInput
+)
+
+
+# input file with sumdata::GeometryConfigurationInfo data product
+#   (one present, one only promised)
+# compatible with current Geometry
+# expected: success (and again data product declared but not put)
+
+cet_test(GeometryInfoCheckCompatible2 HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS
+    --rethrow-all
+    --config ./test_geometry_check_require_geometryA.fcl
+    --process-name MoreProc
+    --source ../GeometryInfoCheckCompatible.d/data_withGeometryA_OnceMore.root
+  DATAFILES
+    test_geometries.fcl test_geometry_checks.fcl
+    test_geometry_check_require_geometryA.fcl
+  TEST_PROPERTIES
+    DEPENDS GeometryInfoCheckCompatible
+)
+
+
+# ------------------------------------------------------------------------------

--- a/test/Geometry/VersionCheck/CMakeLists.txt
+++ b/test/Geometry/VersionCheck/CMakeLists.txt
@@ -27,14 +27,32 @@ cet_test(GeometryInfoCheckEmptyInput HANDBUILT
 
 # no input file, with a job including Geometry service
 # but not the new GeometryConfigurationWriter service;
-# expected: configuration error
+# expected: `ProductNotFound` exception
 
-cet_test(GeometryInfoCheckNoWriter HANDBUILT
+cet_test(q HANDBUILT
   TEST_EXEC lar
   TEST_ARGS --rethrow-all --config ./test_geometry_check_nogeoconfwriter.fcl
-  DATAFILES test_geometries.fcl test_geometry_checks.fcl test_geometry_check_nogeoconfwriter.fcl
+  DATAFILES
+    test_geometries.fcl test_geometry_checks.fcl
+    test_geometry_check_nogeoconfwriter.fcl
   TEST_PROPERTIES
-    DEPENDS GeometryInfoCheckEmptyInput
+    WILL_FAIL TRUE
+)
+
+
+# no input file, with a job including Geometry service
+# but not the new GeometryConfigurationWriter service,
+# and Geometry service is required to skip the check;
+# expected: still `ProductNotFound` exception
+
+cet_test(GeometryInfoCheckNoWriterSkipCheck HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS --rethrow-all --config ./test_geometry_check_nogeoconfwriter_skipcheck.fcl
+  DATAFILES
+    test_geometries.fcl test_geometry_checks.fcl
+    test_geometry_check_nogeoconfwriter.fcl
+    test_geometry_check_nogeoconfwriter_skipcheck.fcl
+  TEST_PROPERTIES
     WILL_FAIL TRUE
 )
 

--- a/test/Geometry/VersionCheck/GeometryInfoCheck_module.cc
+++ b/test/Geometry/VersionCheck/GeometryInfoCheck_module.cc
@@ -1,0 +1,317 @@
+/**
+ * @file   GeometryInfoCheck_module.cc
+ * @brief  Verifies that the geometry check information is available in the run.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   November 11, 2020
+ */
+
+// LArSoft libraries
+#include "larcore/Geometry/Geometry.h"
+#include "larcoreobj/SummaryData/GeometryConfigurationInfo.h"
+#include "larcoreobj/SummaryData/RunData.h"
+
+// framework libraries
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Provenance.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/types/OptionalTable.h"
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/types/Atom.h"
+#include "cetlib_except/exception.h"
+
+// C/C++ standard library
+#include <vector>
+#include <string>
+#include <optional>
+#include <utility> // std::move()
+
+// -----------------------------------------------------------------------------
+namespace art { class Event; }
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Verifies that the geometry check information is available.
+ *
+ * Configuration parameters
+ * =========================
+ *
+ */
+namespace geo { class GeometryInfoCheck; }
+class geo::GeometryInfoCheck: public art::EDAnalyzer {
+    public:
+  
+  struct GeometryInfoConfig {
+    
+    fhicl::OptionalAtom<std::string> Name {
+      fhicl::Name{ "Name" },
+      fhicl::Comment{ "Name of the geometry (if omitted, any will do)" }
+      };
+    
+    fhicl::Atom<bool> Required {
+      fhicl::Name{ "Required" },
+      fhicl::Comment{ "Whether the presence of this item is mandatory" },
+      true
+      };
+    
+  }; // struct GeometryInfoConfig
+  
+  
+  struct Config {
+    
+    fhicl::OptionalTable<GeometryInfoConfig> GeometryInfo {
+      fhicl::Name{ "GeometryInfo" },
+      fhicl::Comment{ "Information to check about geometry" }
+      };
+    
+    fhicl::OptionalTable<GeometryInfoConfig> GeometryLegacyInfo {
+      fhicl::Name{ "LegacyInfo" },
+      fhicl::Comment
+        { "Information to check about geometry (legacy from RunData)" }
+      };
+    
+  }; // struct Config
+  
+  using Parameters = art::EDAnalyzer::Table<Config>;
+  
+  explicit GeometryInfoCheck(Parameters const& config);
+
+  virtual void beginRun(art::Run const& run) override;
+
+  virtual void analyze(art::Event const&) override {}
+  
+    private:
+  
+  struct GeometryInfoCheckInfo {
+    bool required; ///< Whether the information must be present.
+    std::string detectorName; ///< Name of the detector; empty: don't check.
+  };
+  
+  /// Information on the check on the regular geometry information.
+  std::optional<GeometryInfoCheckInfo> fCheckInfo;
+  
+  /// Information on the check on the legacy geometry information.
+  std::optional<GeometryInfoCheckInfo> fLegacyCheckInfo;
+  
+  /// Performs a geometry information check.
+  /// @throw cet::exception on check failures
+  void CheckGeometryInfo
+    (art::Run const& run, GeometryInfoCheckInfo const& config) const;
+  
+  /// Performs a legacy geometry information check
+  /// @throw cet::exception on check failures
+  void CheckLegacyGeometryInfo
+    (art::Run const& run, GeometryInfoCheckInfo const& config) const;
+  
+  
+  /// The name of the tag for the geometry information.
+  static art::InputTag const GeometryConfigurationWriterTag;
+  
+  /// Fills a `GeometryInfoCheckInfo` out of the specified configuration.
+  static std::optional<GeometryInfoCheckInfo> makeGeometryInfoCheckInfo
+    (fhicl::OptionalTable<GeometryInfoConfig> const& config);
+  
+}; // class geo::GeometryInfoCheck
+
+
+// -----------------------------------------------------------------------------
+// ---  geo::GeometryInfoCheck implementation
+// -----------------------------------------------------------------------------
+
+namespace {
+  
+  bool case_insensitive_equal(std::string const& a, std::string const& b) {
+    
+    return std::equal(a.begin(), a.end(), b.begin(), b.end(),
+      [](auto a, auto b)
+        {
+          return ::tolower(static_cast<unsigned char>(a))
+            == ::tolower(static_cast<unsigned char>(b));
+        }
+      );
+    
+  } // case_insensitive_equal()
+  
+} // local namespace
+
+// -----------------------------------------------------------------------------
+art::InputTag const geo::GeometryInfoCheck::GeometryConfigurationWriterTag
+  { "GeometryConfigurationWriter" };
+
+
+// -----------------------------------------------------------------------------
+geo::GeometryInfoCheck::GeometryInfoCheck(Parameters const& config)
+  : art::EDAnalyzer(config)
+  , fCheckInfo(makeGeometryInfoCheckInfo(config().GeometryInfo))
+  , fLegacyCheckInfo(makeGeometryInfoCheckInfo(config().GeometryLegacyInfo))
+{
+  
+  if (fCheckInfo)
+   consumes<sumdata::GeometryConfigurationInfo>(GeometryConfigurationWriterTag);
+  if (fLegacyCheckInfo) consumesMany<sumdata::RunData>();
+  
+  
+  // --- BEGIN -- Configuration dump -------------------------------------------
+  {
+    mf::LogDebug log { "GeometryInfoCheck" };
+    log << "Configuration:"
+      << "\n - geometry configuration check:";
+    if (fCheckInfo) {
+      if (fCheckInfo->detectorName.empty()) log << " (any name)";
+      else log << " must match '" << fCheckInfo->detectorName << "'";
+      log << " [" << (fCheckInfo->required? "mandatory": "optional") << "]";
+    }
+    else log << "not requested";
+    
+    log << "\n - legacy geometry configuration information check:";
+    if (fLegacyCheckInfo) {
+      if (fLegacyCheckInfo->detectorName.empty()) log << " (any name)";
+      else log << " must match '" << fLegacyCheckInfo->detectorName << "'";
+      log << " [" << (fLegacyCheckInfo->required? "mandatory": "optional") << "]";
+    }
+    else log << "not requested";
+    
+  }
+  // --- END -- Configuration dump ---------------------------------------------
+  
+} // geo::GeometryInfoCheck::GeometryInfoCheck()
+
+
+// -----------------------------------------------------------------------------
+void geo::GeometryInfoCheck::beginRun(art::Run const& run) {
+  
+  if (fCheckInfo) CheckGeometryInfo(run, fCheckInfo.value());
+  if (fLegacyCheckInfo) CheckLegacyGeometryInfo(run, fLegacyCheckInfo.value());
+  
+} // geo::GeometryInfoCheck::beginRun()
+
+
+// -----------------------------------------------------------------------------
+void geo::GeometryInfoCheck::CheckGeometryInfo
+  (art::Run const& run, GeometryInfoCheckInfo const& config) const
+{
+  
+  mf::LogDebug log { "GeometryInfoCheck" };
+  log << "Check on geometry information.";
+  
+  //
+  // fetch geometry information
+  //
+  art::Handle<sumdata::GeometryConfigurationInfo> hInfo;
+  if (!run.getByLabel(GeometryConfigurationWriterTag, hInfo)) {
+    log << "\nNo information found.";
+    if (!config.required) return; // well... all ok?
+    
+    log << "\nUnfortunately, that was required...";
+    throw cet::exception("GeometryInfoCheck")
+      << "Required geometry information not found as '"
+      << GeometryConfigurationWriterTag.encode() << "'\n";
+  } // if no info
+  
+  sumdata::GeometryConfigurationInfo const& info { *hInfo };
+  log
+    << "\nFound geometry information (version " << info.dataVersion << ")"
+      << " from '" << hInfo.provenance()->inputTag().encode() << "'"
+    << "\nGeometry name is '" << info.detectorName << "'."
+    ;
+  
+  //
+  // check: the name
+  //
+  if (!config.detectorName.empty()
+    && !case_insensitive_equal(info.detectorName, config.detectorName)
+  ) {
+    throw cet::exception("GeometryInfoCheck")
+      << "Geometry information reports an unexpected name '"
+      << info.detectorName << "' ('" << config.detectorName << "' expected)\n"
+      ;
+  } // if
+  
+  //
+  // all checks done
+  //
+  
+} // geo::GeometryInfoCheck::CheckGeometryInfo()
+
+
+// -----------------------------------------------------------------------------
+void geo::GeometryInfoCheck::CheckLegacyGeometryInfo
+  (art::Run const& run, GeometryInfoCheckInfo const& config) const
+{
+  
+  mf::LogDebug log { "GeometryInfoCheck" };
+  log << "Check on legacy geometry information.";
+  
+  //
+  // fetch geometry information
+  //
+  std::vector<art::Handle<sumdata::RunData>> hInfoList;
+  run.getManyByType(hInfoList);
+  if (hInfoList.empty()) {
+    log << "\nNo information found.";
+    if (!config.required) return; // well... all ok?
+    
+    log << "\nUnfortunately, that was required...";
+    throw cet::exception("GeometryInfoCheck")
+      << "No legacy geometry information found!\n";
+  } // if no info
+  
+  log << "\nFound " << hInfoList.size() << " legacy geometry records:";
+  art::Handle<sumdata::RunData> const* hInfo = nullptr;
+  for (auto const& handle: hInfoList) {
+    log << "\n - " << handle.provenance()->inputTag().encode();
+    if (handle.failedToGet()) log << " (not present)";
+    else if (!hInfo) {
+      hInfo = &handle;
+      log << " (this will be used for the check)";
+    }
+  } // for all handles
+  
+  sumdata::RunData const& info { *(hInfo->product()) };
+  log
+    << "\nFound legacy geometry information "
+    << "\nGeometry name is '" << info.DetName() << "'."
+    ;
+  
+  //
+  // check: the name
+  //
+  if (!config.detectorName.empty()
+    && !case_insensitive_equal(info.DetName(), config.detectorName)
+  ) {
+    throw cet::exception("GeometryInfoCheck")
+      << "Geometry legacy information reports an unexpected name '"
+      << info.DetName() << "' ('" << config.detectorName << "' expected)\n"
+      ;
+  } // if
+  
+  //
+  // all checks done
+  //
+  
+} // geo::GeometryInfoCheck::CheckLegacyGeometryInfo()
+
+
+// -----------------------------------------------------------------------------
+auto geo::GeometryInfoCheck::makeGeometryInfoCheckInfo
+  (fhicl::OptionalTable<GeometryInfoConfig> const& config)
+  -> std::optional<GeometryInfoCheckInfo>
+{
+  GeometryInfoConfig infoConfig;
+  if (!config(infoConfig)) return {};
+  
+  GeometryInfoCheckInfo info;
+  info.required = infoConfig.Required();
+  infoConfig.Name(info.detectorName); // so far, not specifying it defaults to empty
+  
+  return { std::move(info) };
+} // geo::GeometryInfoCheck::makeGeometryInfoCheckInfo()
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_MODULE(geo::GeometryInfoCheck)
+
+
+// -----------------------------------------------------------------------------

--- a/test/Geometry/VersionCheck/LegacyGeometryInfoWriter_module.cc
+++ b/test/Geometry/VersionCheck/LegacyGeometryInfoWriter_module.cc
@@ -1,0 +1,109 @@
+/**
+ * @file   LegacyGeometryInfoWriter_module.cc
+ * @brief  Writes a sumdata::RunData record into the run(s).
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   November 12, 2020
+ */
+
+// LArSoft libraries
+#include "larcoreobj/SummaryData/RunData.h"
+
+// framework libraries
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Run.h"
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard library
+#include <string>
+#include <algorithm> // std::transform()
+#include <iterator> // std::back_inserter()
+#include <memory> // std::make_unique()
+
+// -----------------------------------------------------------------------------
+namespace art { class Event; }
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Writes a sumdata::RunData record into the run(s).
+ *
+ * A copy of the same data product is put into each of the runs on opening.
+ *
+ *
+ * Configuration parameters
+ * =========================
+ *
+ * * `Name` (string, mandatory): name of the detector to be stored in the
+ *     `sumdata::RunData` data product
+ *
+ */
+namespace geo { class LegacyGeometryInfoWriter; }
+class geo::LegacyGeometryInfoWriter: public art::EDProducer {
+    public:
+  
+  struct Config {
+    
+    fhicl::Atom<std::string> Name {
+      fhicl::Name{ "Name" },
+      fhicl::Comment{ "Name of the detector to be stored in the data" }
+      };
+    
+  }; // struct Config
+  
+  using Parameters = art::EDProducer::Table<Config>;
+  
+  explicit LegacyGeometryInfoWriter(Parameters const& config);
+
+  virtual void beginRun(art::Run& run) override;
+
+  virtual void produce(art::Event&) override {}
+  
+    private:
+  
+  std::string fDetectorName; ///< Name of the detector.
+  
+}; // class geo::LegacyGeometryInfoWriter
+
+
+// -----------------------------------------------------------------------------
+// ---  geo::LegacyGeometryInfoWriter implementation
+// -----------------------------------------------------------------------------
+
+namespace {
+  
+  std::string toLower(std::string const& S) {
+    
+    std::string s;
+    s.reserve(S.length());
+    std::transform(S.begin(), S.end(), back_inserter(s), ::tolower);
+    return s;
+    
+  } // toLower()
+  
+} // local namespace
+
+// -----------------------------------------------------------------------------
+geo::LegacyGeometryInfoWriter::LegacyGeometryInfoWriter
+  (Parameters const& config)
+  : art::EDProducer(config)
+  , fDetectorName(::toLower(config().Name()))
+{
+  
+  produces<sumdata::RunData, art::InRun>();
+  
+} // geo::LegacyGeometryInfoWriter::LegacyGeometryInfoWriter()
+
+
+// -----------------------------------------------------------------------------
+void geo::LegacyGeometryInfoWriter::beginRun(art::Run& run) {
+  
+  run.put(std::make_unique<sumdata::RunData>(fDetectorName), art::fullRun());
+  
+} // geo::LegacyGeometryInfoWriter::beginRun()
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_MODULE(geo::LegacyGeometryInfoWriter)
+
+
+// -----------------------------------------------------------------------------

--- a/test/Geometry/VersionCheck/test_geometries.fcl
+++ b/test/Geometry/VersionCheck/test_geometries.fcl
@@ -1,0 +1,58 @@
+#
+# File:    test_geometries.fcl
+# Purpose: Service configuration settings for geometry information check tests.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 11, 2020
+#
+# Two "alternative" geometries are provided (they just differ by their name):
+# 
+# * `test_geometry_check_services_A`
+# * `test_geometry_check_services_B`
+#
+# It also provides a `messages` service configuration for debugging.
+#
+
+#include "geometry_lartpcdetector.fcl"
+
+BEGIN_PROLOG
+
+# ------------------------------------------------------------------------------
+test_geometry_check_services_A: {
+  
+  @table::lartpcdetector_geometry_services
+  
+} # test_geometry_check_services_A
+
+test_geometry_check_services_A.Geometry.Name: "A"
+
+
+# ------------------------------------------------------------------------------
+test_geometry_check_services_B: {
+  
+  @table::lartpcdetector_geometry_services
+  
+} # test_geometry_check_services_B
+
+test_geometry_check_services_B.Geometry.Name: "B"
+
+
+# ------------------------------------------------------------------------------
+message_services_interactive_debug: {
+  destinations: {
+    AllDebug: {
+      #
+      # message destination: all debug messages to console
+      #
+      type:       "cout"
+      threshold:  "DEBUG"
+      categories: {
+        default: {}
+      }
+    } # AllDebug
+
+  } # destinations
+} # message_services_interactive_debug
+
+
+
+END_PROLOG

--- a/test/Geometry/VersionCheck/test_geometry_check_empty.fcl
+++ b/test/Geometry/VersionCheck/test_geometry_check_empty.fcl
@@ -1,0 +1,50 @@
+#
+# File:    test_geometry_check_empty.fcl
+# Purpose: Produces data for geometry version check test on no input.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 11, 2020
+#
+# Input: none
+# 
+#
+#
+
+#include "test_geometries.fcl"
+#include "test_geometry_checks.fcl"
+
+
+process_name: GeoA
+
+
+services: {
+  
+  message: @local::message_services_interactive_debug # from test_geometries.fcl
+  
+           @table::test_geometry_check_services_A     # from test_geometries.fcl
+  
+} # services
+
+
+physics: {
+  
+  analyzers: {
+  
+    geocheck: @local::geometry_check_test_A # from test_geometry_checks.fcl
+  
+  } # analyzers
+  
+  checks:  [ geocheck ]
+  streams: [ rootoutput ]
+  
+} # physics
+
+
+outputs: {
+  rootoutput: {
+    
+    module_type: RootOutput
+    
+    fileName: "EmptyWithGeometryA.root"
+    
+  } # rootoutput
+} # outputs

--- a/test/Geometry/VersionCheck/test_geometry_check_geometryA_skipCheck.fcl
+++ b/test/Geometry/VersionCheck/test_geometry_check_geometryA_skipCheck.fcl
@@ -1,0 +1,25 @@
+#
+# File:    test_geometry_check_geometryA_skipCheck.fcl
+# Purpose: Job with geometry A on input file, skips the check.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 12, 2020
+#
+# Input:  file prepared with Geometry service
+# Output: none
+#
+
+#include "test_geometries.fcl"
+
+
+process_name: GeoAworker
+
+
+services: {
+  
+  message: @local::message_services_interactive_debug # from test_geometries.fcl
+  
+           @table::test_geometry_check_services_A     # from test_geometries.fcl
+  
+} # services
+
+services.Geometry.SkipConfigurationCheck: true

--- a/test/Geometry/VersionCheck/test_geometry_check_geometryB_skipCheck.fcl
+++ b/test/Geometry/VersionCheck/test_geometry_check_geometryB_skipCheck.fcl
@@ -1,0 +1,25 @@
+#
+# File:    test_geometry_check_geometryB_skipCheck.fcl
+# Purpose: Job with geometry B on input file, skips the check.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 12, 2020
+#
+# Input:  file prepared with Geometry service
+# Output: none
+#
+
+#include "test_geometries.fcl"
+
+
+process_name: GeoBworker
+
+
+services: {
+  
+  message: @local::message_services_interactive_debug # from test_geometries.fcl
+  
+           @table::test_geometry_check_services_B     # from test_geometries.fcl
+  
+} # services
+
+services.Geometry.SkipConfigurationCheck: true

--- a/test/Geometry/VersionCheck/test_geometry_check_make_legacy_input.fcl
+++ b/test/Geometry/VersionCheck/test_geometry_check_make_legacy_input.fcl
@@ -1,0 +1,41 @@
+#
+# File:    test_geometry_check_make_legacy_input.fcl
+# Purpose: Produces a file with legacy detector geometry ("A") information.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 12, 2020
+#
+# Input:  none
+# Output: set on command line
+#
+#
+
+#include "test_geometries.fcl"
+
+
+process_name: GeoAlegacy
+
+
+services: {
+  
+  message: @local::message_services_interactive_debug # from test_geometries.fcl
+  
+} # services
+
+
+physics: {
+  
+  producers: {
+  
+    generator: {
+      
+      module_type: LegacyGeometryInfoWriter
+      
+      Name: "A"
+      
+    } // generator
+  
+  } # producers
+  
+  simulate:  [ generator ]
+  
+} # physics

--- a/test/Geometry/VersionCheck/test_geometry_check_nogeoconfwriter.fcl
+++ b/test/Geometry/VersionCheck/test_geometry_check_nogeoconfwriter.fcl
@@ -1,0 +1,38 @@
+#
+# File:    test_geometry_check_nogeoconfwriter.fcl
+# Purpose: Job with geometry but without GeometryConfigurationWriter.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 11, 2020
+#
+# Input: none
+#
+
+#include "test_geometries.fcl"
+#include "test_geometry_checks.fcl"
+
+
+process_name: GeoCheckTest
+
+
+services: {
+  
+  message: @local::message_services_interactive_debug # from test_geometries.fcl
+  
+           @table::test_geometry_check_services_A     # from test_geometries.fcl
+  
+} # services
+services.GeometryConfigurationWriter: @erase
+
+
+physics: {
+  
+  analyzers: {
+  
+    geocheck: @local::geometry_check_test_A # from test_geometry_checks.fcl
+  
+  } # analyzers
+  
+  checks:  [ geocheck ]
+  
+} # physics
+

--- a/test/Geometry/VersionCheck/test_geometry_check_nogeoconfwriter_skipcheck.fcl
+++ b/test/Geometry/VersionCheck/test_geometry_check_nogeoconfwriter_skipcheck.fcl
@@ -1,0 +1,13 @@
+#
+# File:    test_geometry_check_nogeoconfwriter_skipcheck.fcl
+# Purpose: Job with geometry but without GeometryConfigurationWriter,
+#          and the request to skip the check.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 11, 2020
+#
+# Input: none
+#
+
+#include "test_geometry_check_nogeoconfwriter.fcl"
+
+services.Geometry.SkipConfigurationCheck: true

--- a/test/Geometry/VersionCheck/test_geometry_check_require_geometryA.fcl
+++ b/test/Geometry/VersionCheck/test_geometry_check_require_geometryA.fcl
@@ -1,0 +1,39 @@
+#
+# File:    test_geometry_check_require_geometryA.fcl
+# Purpose: Job with geometry A on input file.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 12, 2020
+#
+# Input:  file prepared with Geometry service
+# Output: none
+#
+
+#include "test_geometries.fcl"
+#include "test_geometry_checks.fcl"
+
+
+process_name: GeoAcheckTest
+
+
+services: {
+  
+  message: @local::message_services_interactive_debug # from test_geometries.fcl
+  
+           @table::test_geometry_check_services_A     # from test_geometries.fcl
+  
+} # services
+
+
+physics: {
+  
+  analyzers: {
+  
+    geocheck: @local::geometry_check_test_A # from test_geometry_checks.fcl
+  
+  } # analyzers
+  
+  checks:  [ geocheck ]
+  
+} # physics
+
+

--- a/test/Geometry/VersionCheck/test_geometry_check_require_geometryB.fcl
+++ b/test/Geometry/VersionCheck/test_geometry_check_require_geometryB.fcl
@@ -1,0 +1,38 @@
+#
+# File:    test_geometry_check_require_geometryB.fcl
+# Purpose: Job with geometry B on input file.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 12, 2020
+#
+# Input:  file prepared with Geometry service
+# Output: none
+#
+
+#include "test_geometries.fcl"
+#include "test_geometry_checks.fcl"
+
+
+process_name: GeoBcheckTest
+
+
+services: {
+  
+  message: @local::message_services_interactive_debug # from test_geometries.fcl
+  
+           @table::test_geometry_check_services_B     # from test_geometries.fcl
+  
+} # services
+
+
+physics: {
+  
+  analyzers: {
+  
+    geocheck: @local::geometry_check_test_B # from test_geometry_checks.fcl
+  
+  } # analyzers
+  
+  checks:  [ geocheck ]
+  
+} # physics
+

--- a/test/Geometry/VersionCheck/test_geometry_checks.fcl
+++ b/test/Geometry/VersionCheck/test_geometry_checks.fcl
@@ -1,0 +1,44 @@
+#
+# File:    test_geometry_checks.fcl
+# Purpose: Template configuration for geometry configuration explicit check.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 11, 2020
+#
+
+BEGIN_PROLOG
+
+# ------------------------------------------------------------------------------
+geometry_check_test_A: {
+  module_type: GeometryInfoCheck
+  
+  GeometryInfo: {
+    Name: "a"
+  }
+  
+  LegacyInfo: {
+    Name:    "a"
+    Required: false
+  }
+  
+} # geometry_check_test_A
+
+
+# ------------------------------------------------------------------------------
+geometry_check_test_B: {
+  module_type: GeometryInfoCheck
+  
+  GeometryInfo: {
+    Name: "b"
+  }
+  
+  LegacyInfo: {
+    Name:    "b"
+    Required: false
+  }
+  
+} # geometry_check_test_B
+
+
+# ------------------------------------------------------------------------------
+
+END_PROLOG

--- a/test/Geometry/dump_lartpcdetector_channelmap.fcl
+++ b/test/Geometry/dump_lartpcdetector_channelmap.fcl
@@ -15,8 +15,7 @@ process_name: DumpChannelMap
 
 services: {
   
-  Geometry:               @local::standard_geo
-  ExptGeoHelperInterface: @local::standard_geometry_helper
+  @table::standard_geometry_services
   
   message: {
     destinations: {


### PR DESCRIPTION
This is part of the pull request set including also LArSoft/larcoreobj#9.
Breaking changes need to be resolved by the experiments: the resolution for LArSoft is in LArSoft/larcorealg#12, LArSoft/lardataalg#18, LArSoft/lardata#12, LArSoft/larevt#10, LArSoft/larsim#56, LArSoft/larreco#24, LArSoft/larexamples#5 _(edited 20201207)_ and LArSoft/lareventdisplay#10 _(edited 20201214)_
The branches offered for evaluation to the experiments, all named `feature/gp_issue24328`, are in the following repositories:
* ArgoNeuT: `argoneutcode`
* DUNE: `dunetpc`
* ICARUS: `sbncode`, `icarusalg`, `icaruscode`
* SBND: `sbncode`, `sbndcode`
* MicroBooNE: `uboonecode`, `ubana`, `ubcrt`, `ubcv`, `ubevt`, `ublite`, `ubraw`, `ubreco`, `ubsim`
_(edited 20201214)_

This is the resolution of [Redmine issue #24328](https://cdcvs.fnal.gov/redmine/issues/24328).
The main discussion on the issue resolution will happen in this pull request.

A refresher of how the solution is deployed is in the new documentation of `geo::Geometry` class. That text is the reference design of the solution.

The feature has been "manually" tested by providing crafted inputs to configurations all including `Geometry` service and, unless otherwise specified, `GeometryConfigurationWriter` service:
* no input file (source: `EmptyEvent`): geometry information added to output file
* empty input file, with a job not including the new `GeometryConfigurationWriter` service: configuration error
* empty input file: geometry information added to output file
* input file with `sumdata::RunData` data product compatible with current `Geometry`: geometry information added to output file
* input file with `sumdata::RunData` data product not compatible with current `Geometry`: exception showing the different configurations
* input file with `sumdata::GeometryConfigurationInfo` data product compatible with current `Geometry`: **data product declared but not put**; but the job still succeeds as required
* input file with `sumdata::GeometryConfigurationInfo` data product not compatible with current `Geometry`: exception showing the different configurations

Further action is needed to address the data product declared but not put (because one already existed). I have discussed with @knoepfel who confirmed that _art_ is currently not enforcing the insertion of a declared data product in the context that this feature uses, and that we can go along with that and fix it in an unlikely future where this check becomes enforced.

## Breaking change and resolution

The new feature _requires_ the experiments to run `GeometryConfigurationWriter` service when an input file which has never seen `Geometry` service is processed with a job that sets `Geometry` service up. The easiest (and safe) way to do that is to configure `GeometryConfigurationWriter` together with `Geometry` and `ExptGeoHelperInterface`, and run it every time.
The recommended way to configure the geometry was something like:
```
experiment_geometry_services: {
  Geometry:               @local::experiment_geometry
  ExptGeoHelperInterface: @local::experiment_geometry_helper
}
```
with the user configurations including something like:
```
services: {
  @table::experiment_geometry_services
  # ...
}
```
In this scenario, the configuration fix is to change the `experiment_geometry_services` configuration table as follows:
```
experiment_geometry_services: {
  Geometry:               @local::experiment_geometry
  ExptGeoHelperInterface: @local::experiment_geometry_helper
  GeometryConfigurationWriter: {}
}
```
In the cases where a geometry configuration bundle is not used, the line `services.GeometryConfigurationWriter: {}` or equivalent must be added to the configuration.

If there are reasons to wish to skip the check, `Geometry` service can be instructed to do so, with an option like:
```
services.Geometry.SkipConfigurationCheck: true
```
**Note**: the service `GeometryConfigurationWriter` must be configured even if the check is skipped with `SkipConfigurationCheck` set to `true`.